### PR TITLE
feat(search): multi-mode Cmd+K search palette

### DIFF
--- a/src/backend/src/docs/markdown.rs
+++ b/src/backend/src/docs/markdown.rs
@@ -72,6 +72,9 @@ pub fn render_document(
     sanitizer.add_tag_attributes("p", &["class"]);
     sanitizer.add_tag_attributes("span", &["class", "data-type"]);
     sanitizer.add_tags(&["mark", "details", "summary"]);
+    for tag in &["h1", "h2", "h3", "h4", "h5", "h6"] {
+        sanitizer.add_tag_attributes(tag, &["id"]);
+    }
     let sanitized = sanitizer.clean(&html).to_string();
     let sanitized = restore_callout_icons(&sanitized);
     (frontmatter, sanitized)
@@ -493,8 +496,21 @@ pub fn extract_tags(raw: &str) -> Vec<String> {
     tags
 }
 
+/// Generate a URL-safe anchor slug from heading text.
+/// Lowercase, spaces to hyphens, strip non-alphanumeric except hyphens.
+pub fn slugify(text: &str) -> String {
+    text.to_lowercase()
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
 fn render_markdown(body: &str) -> String {
-    use pulldown_cmark::{html, Options, Parser};
+    use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd, HeadingLevel};
 
     let options = Options::ENABLE_TABLES
         | Options::ENABLE_STRIKETHROUGH
@@ -503,6 +519,60 @@ fn render_markdown(body: &str) -> String {
 
     let parser = Parser::new_ext(body, options);
     let mut html_output = String::new();
-    html::push_html(&mut html_output, parser);
+    let mut heading_text = String::new();
+    let mut in_heading = false;
+    let mut heading_level: Option<HeadingLevel> = None;
+    let mut slug_counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+
+    for event in parser {
+        match event {
+            Event::Start(Tag::Heading { level, .. }) => {
+                in_heading = true;
+                heading_level = Some(level);
+                heading_text.clear();
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                in_heading = false;
+                let base_slug = slugify(&heading_text);
+                let count = slug_counts.entry(base_slug.clone()).or_insert(0);
+                let slug = if *count == 0 {
+                    base_slug.clone()
+                } else {
+                    format!("{base_slug}-{count}")
+                };
+                *count += 1;
+
+                let level_num = match heading_level {
+                    Some(HeadingLevel::H1) => 1,
+                    Some(HeadingLevel::H2) => 2,
+                    Some(HeadingLevel::H3) => 3,
+                    Some(HeadingLevel::H4) => 4,
+                    Some(HeadingLevel::H5) => 5,
+                    Some(HeadingLevel::H6) => 6,
+                    None => 1,
+                };
+                html_output.push_str(&format!(
+                    "<h{level_num} id=\"{slug}\">{heading_text}</h{level_num}>\n"
+                ));
+                heading_text.clear();
+                heading_level = None;
+            }
+            Event::Text(ref t) if in_heading => {
+                heading_text.push_str(t);
+            }
+            Event::Code(ref t) if in_heading => {
+                heading_text.push_str(t);
+            }
+            _ if in_heading => {
+                // Skip inline formatting events inside headings - plain text only
+            }
+            other => {
+                let mut tmp = String::new();
+                pulldown_cmark::html::push_html(&mut tmp, std::iter::once(other));
+                html_output.push_str(&tmp);
+            }
+        }
+    }
+
     html_output
 }

--- a/src/backend/src/docs/markdown.rs
+++ b/src/backend/src/docs/markdown.rs
@@ -496,6 +496,74 @@ pub fn extract_tags(raw: &str) -> Vec<String> {
     tags
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct HeadingInfo {
+    pub level: u8,
+    pub text: String,
+    pub anchor: String,
+}
+
+/// Extract all headings from raw markdown content.
+pub fn extract_headings(raw: &str) -> Vec<HeadingInfo> {
+    use pulldown_cmark::{Event, Parser, Tag, TagEnd, HeadingLevel};
+
+    let (_, body) = parse_frontmatter(raw);
+    let parser = Parser::new(body);
+    let mut headings = Vec::new();
+    let mut heading_text = String::new();
+    let mut in_heading = false;
+    let mut current_level: Option<HeadingLevel> = None;
+    let mut slug_counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+
+    for event in parser {
+        match event {
+            Event::Start(Tag::Heading { level, .. }) => {
+                in_heading = true;
+                current_level = Some(level);
+                heading_text.clear();
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                in_heading = false;
+                let base_slug = slugify(&heading_text);
+                let count = slug_counts.entry(base_slug.clone()).or_insert(0);
+                let anchor = if *count == 0 {
+                    base_slug.clone()
+                } else {
+                    format!("{base_slug}-{count}")
+                };
+                *count += 1;
+
+                let level_num = match current_level {
+                    Some(HeadingLevel::H1) => 1,
+                    Some(HeadingLevel::H2) => 2,
+                    Some(HeadingLevel::H3) => 3,
+                    Some(HeadingLevel::H4) => 4,
+                    Some(HeadingLevel::H5) => 5,
+                    Some(HeadingLevel::H6) => 6,
+                    None => 1,
+                };
+
+                headings.push(HeadingInfo {
+                    level: level_num,
+                    text: heading_text.clone(),
+                    anchor,
+                });
+                heading_text.clear();
+                current_level = None;
+            }
+            Event::Text(ref t) if in_heading => {
+                heading_text.push_str(t);
+            }
+            Event::Code(ref t) if in_heading => {
+                heading_text.push_str(t);
+            }
+            _ => {}
+        }
+    }
+
+    headings
+}
+
 /// Generate a URL-safe anchor slug from heading text.
 /// Lowercase, spaces to hyphens, strip non-alphanumeric except hyphens.
 pub fn slugify(text: &str) -> String {

--- a/src/backend/src/docs/markdown.rs
+++ b/src/backend/src/docs/markdown.rs
@@ -505,15 +505,15 @@ pub struct HeadingInfo {
 
 /// Extract all headings from raw markdown content.
 pub fn extract_headings(raw: &str) -> Vec<HeadingInfo> {
-    use pulldown_cmark::{Event, Parser, Tag, TagEnd, HeadingLevel};
+    use pulldown_cmark::{Event, Parser, Tag, TagEnd};
 
     let (_, body) = parse_frontmatter(raw);
     let parser = Parser::new(body);
     let mut headings = Vec::new();
     let mut heading_text = String::new();
     let mut in_heading = false;
-    let mut current_level: Option<HeadingLevel> = None;
-    let mut slug_counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut current_level: Option<pulldown_cmark::HeadingLevel> = None;
+    let mut slugs = SlugCounter::new();
 
     for event in parser {
         match event {
@@ -524,24 +524,8 @@ pub fn extract_headings(raw: &str) -> Vec<HeadingInfo> {
             }
             Event::End(TagEnd::Heading(_)) => {
                 in_heading = false;
-                let base_slug = slugify(&heading_text);
-                let count = slug_counts.entry(base_slug.clone()).or_insert(0);
-                let anchor = if *count == 0 {
-                    base_slug.clone()
-                } else {
-                    format!("{base_slug}-{count}")
-                };
-                *count += 1;
-
-                let level_num = match current_level {
-                    Some(HeadingLevel::H1) => 1,
-                    Some(HeadingLevel::H2) => 2,
-                    Some(HeadingLevel::H3) => 3,
-                    Some(HeadingLevel::H4) => 4,
-                    Some(HeadingLevel::H5) => 5,
-                    Some(HeadingLevel::H6) => 6,
-                    None => 1,
-                };
+                let anchor = slugs.next_slug(&heading_text);
+                let level_num = current_level.map(heading_level_to_u8).unwrap_or(1);
 
                 headings.push(HeadingInfo {
                     level: level_num,
@@ -557,11 +541,44 @@ pub fn extract_headings(raw: &str) -> Vec<HeadingInfo> {
             Event::Code(ref t) if in_heading => {
                 heading_text.push_str(t);
             }
+            Event::SoftBreak | Event::HardBreak if in_heading => {
+                heading_text.push(' ');
+            }
             _ => {}
         }
     }
 
     headings
+}
+
+struct SlugCounter {
+    counts: std::collections::HashMap<String, usize>,
+}
+
+impl SlugCounter {
+    fn new() -> Self {
+        Self { counts: std::collections::HashMap::new() }
+    }
+
+    fn next_slug(&mut self, text: &str) -> String {
+        let base = slugify(text);
+        let count = self.counts.entry(base.clone()).or_insert(0);
+        let slug = if *count == 0 { base.clone() } else { format!("{base}-{count}") };
+        *count += 1;
+        slug
+    }
+}
+
+fn heading_level_to_u8(level: pulldown_cmark::HeadingLevel) -> u8 {
+    use pulldown_cmark::HeadingLevel;
+    match level {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    }
 }
 
 /// Generate a URL-safe anchor slug from heading text.
@@ -578,7 +595,7 @@ pub fn slugify(text: &str) -> String {
 }
 
 fn render_markdown(body: &str) -> String {
-    use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd, HeadingLevel};
+    use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
 
     let options = Options::ENABLE_TABLES
         | Options::ENABLE_STRIKETHROUGH
@@ -589,8 +606,8 @@ fn render_markdown(body: &str) -> String {
     let mut html_output = String::new();
     let mut heading_text = String::new();
     let mut in_heading = false;
-    let mut heading_level: Option<HeadingLevel> = None;
-    let mut slug_counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut heading_level: Option<pulldown_cmark::HeadingLevel> = None;
+    let mut slugs = SlugCounter::new();
 
     for event in parser {
         match event {
@@ -601,24 +618,8 @@ fn render_markdown(body: &str) -> String {
             }
             Event::End(TagEnd::Heading(_)) => {
                 in_heading = false;
-                let base_slug = slugify(&heading_text);
-                let count = slug_counts.entry(base_slug.clone()).or_insert(0);
-                let slug = if *count == 0 {
-                    base_slug.clone()
-                } else {
-                    format!("{base_slug}-{count}")
-                };
-                *count += 1;
-
-                let level_num = match heading_level {
-                    Some(HeadingLevel::H1) => 1,
-                    Some(HeadingLevel::H2) => 2,
-                    Some(HeadingLevel::H3) => 3,
-                    Some(HeadingLevel::H4) => 4,
-                    Some(HeadingLevel::H5) => 5,
-                    Some(HeadingLevel::H6) => 6,
-                    None => 1,
-                };
+                let slug = slugs.next_slug(&heading_text);
+                let level_num = heading_level.map(heading_level_to_u8).unwrap_or(1);
                 html_output.push_str(&format!(
                     "<h{level_num} id=\"{slug}\">{heading_text}</h{level_num}>\n"
                 ));
@@ -630,6 +631,9 @@ fn render_markdown(body: &str) -> String {
             }
             Event::Code(ref t) if in_heading => {
                 heading_text.push_str(t);
+            }
+            Event::SoftBreak | Event::HardBreak if in_heading => {
+                heading_text.push(' ');
             }
             _ if in_heading => {
                 // Skip inline formatting events inside headings - plain text only

--- a/src/backend/src/search/handlers.rs
+++ b/src/backend/src/search/handlers.rs
@@ -16,13 +16,26 @@ use crate::search::index::SearchIndex;
 
 type VaultConfigsMap = Arc<RwLock<HashMap<String, VaultConfigCache>>>;
 
+#[derive(Deserialize, Default, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum SearchType {
+    #[default]
+    Content,
+    Files,
+    Tags,
+    Headings,
+}
+
 #[derive(Deserialize)]
 pub struct SearchParams {
-    pub q: String,
+    pub q: Option<String>,
     #[serde(default = "default_vault")]
     pub vault: String,
     #[serde(default = "default_limit")]
     pub limit: usize,
+    #[serde(default)]
+    pub r#type: SearchType,
+    pub tag: Option<String>,
 }
 
 fn default_vault() -> String {
@@ -39,6 +52,22 @@ pub struct SearchResultResponse {
     pub title: String,
     pub snippet: String,
     pub score: f32,
+    pub result_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doc_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heading_level: Option<u8>,
+}
+
+enum RawSearchData {
+    Content(Vec<crate::search::index::SearchResult>),
+    Files(Vec<crate::search::index::SearchResult>),
+    Tags(Vec<crate::search::index::TagSearchResult>),
+    Headings(Vec<crate::search::index::HeadingSearchResult>),
 }
 
 pub async fn search(
@@ -51,33 +80,63 @@ pub async fn search(
     vault_configs: VaultConfigsMap,
     vault_name: &str,
 ) -> Response {
-    if params.q.is_empty() {
+    let q = params.q.clone().unwrap_or_default();
+    let tag = params.tag.clone();
+    let search_type = params.r#type.clone();
+    let limit = params.limit.min(100);
+
+    let is_tags_type = matches!(search_type, SearchType::Tags);
+    if q.is_empty() && tag.is_none() && !is_tags_type {
         return Json(Vec::<SearchResultResponse>::new()).into_response();
     }
 
-    let limit = params.limit.min(100);
+    let raw_data = {
+        let index_guard = search_index.read().await;
+        let index = match index_guard.as_ref() {
+            Some(idx) => idx,
+            None => return Json(Vec::<SearchResultResponse>::new()).into_response(),
+        };
 
-    let index_guard = search_index.read().await;
-    let index = match index_guard.as_ref() {
-        Some(idx) => idx,
-        None => return Json(Vec::<SearchResultResponse>::new()).into_response(),
+        match search_type {
+            SearchType::Content => {
+                if q.is_empty() {
+                    return Json(Vec::<SearchResultResponse>::new()).into_response();
+                }
+                RawSearchData::Content(index.search(&q, limit * 2))
+            }
+            SearchType::Files => {
+                if q.is_empty() {
+                    return Json(Vec::<SearchResultResponse>::new()).into_response();
+                }
+                RawSearchData::Files(index.search_files(&q, limit * 2))
+            }
+            SearchType::Tags => {
+                if let Some(ref exact_tag) = tag {
+                    RawSearchData::Tags(index.search_by_tag(exact_tag, limit * 2))
+                } else if q.is_empty() {
+                    RawSearchData::Tags(index.all_tags())
+                } else {
+                    RawSearchData::Tags(index.search_tags(&q, limit * 2))
+                }
+            }
+            SearchType::Headings => {
+                if q.is_empty() {
+                    return Json(Vec::<SearchResultResponse>::new()).into_response();
+                }
+                RawSearchData::Headings(index.search_headings(&q, limit * 2))
+            }
+        }
     };
 
-    // Fetch extra results to account for post-filter role removal
-    let raw_results = index.search(&params.q, limit * 2);
-    drop(index_guard);
-
     if auth_mode == AuthMode::None {
-        let results: Vec<SearchResultResponse> = raw_results
-            .into_iter()
-            .take(limit)
-            .map(|r| SearchResultResponse {
-                path: r.path,
-                title: r.title,
-                snippet: r.snippet,
-                score: r.score,
-            })
-            .collect();
+        let results = tokio::task::spawn_blocking(move || match raw_data {
+            RawSearchData::Content(raw) => filter_and_map_content(raw, limit),
+            RawSearchData::Files(raw) => filter_and_map_files(raw, limit),
+            RawSearchData::Tags(raw) => aggregate_tags(raw, &q, limit),
+            RawSearchData::Headings(raw) => expand_headings(raw, &q, limit),
+        })
+        .await
+        .unwrap_or_default();
         return Json(results).into_response();
     }
 
@@ -86,24 +145,176 @@ pub async fn search(
         guard.get(vault_name).cloned().unwrap_or_default()
     };
 
-    let filtered = tokio::task::spawn_blocking(move || {
-        raw_results
-            .into_iter()
-            .filter(|r| {
-                let roles = vault_config::resolve_roles(&configs, &r.path, &default_roles);
-                vault_config::check_access(&user.roles, &roles)
-            })
-            .take(limit)
-            .map(|r| SearchResultResponse {
-                path: r.path,
-                title: r.title,
-                snippet: r.snippet,
-                score: r.score,
-            })
-            .collect::<Vec<_>>()
+    let results = tokio::task::spawn_blocking(move || match raw_data {
+        RawSearchData::Content(raw) => {
+            let filtered = filter_by_access(raw, &user, &configs, &default_roles);
+            filter_and_map_content(filtered, limit)
+        }
+        RawSearchData::Files(raw) => {
+            let filtered = filter_by_access(raw, &user, &configs, &default_roles);
+            filter_and_map_files(filtered, limit)
+        }
+        RawSearchData::Tags(raw) => {
+            let filtered = filter_tags_by_access(raw, &user, &configs, &default_roles);
+            aggregate_tags(filtered, &q, limit)
+        }
+        RawSearchData::Headings(raw) => {
+            let filtered = filter_headings_by_access(raw, &user, &configs, &default_roles);
+            expand_headings(filtered, &q, limit)
+        }
     })
     .await
     .unwrap_or_default();
 
-    Json(filtered).into_response()
+    Json(results).into_response()
+}
+
+fn check_user_access(
+    path: &str,
+    user: &User,
+    configs: &VaultConfigCache,
+    default_roles: &[String],
+) -> bool {
+    let roles = vault_config::resolve_roles(configs, path, default_roles);
+    vault_config::check_access(&user.roles, &roles)
+}
+
+fn filter_by_access(
+    raw: Vec<crate::search::index::SearchResult>,
+    user: &User,
+    configs: &VaultConfigCache,
+    default_roles: &[String],
+) -> Vec<crate::search::index::SearchResult> {
+    raw.into_iter()
+        .filter(|r| check_user_access(&r.path, user, configs, default_roles))
+        .collect()
+}
+
+fn filter_tags_by_access(
+    raw: Vec<crate::search::index::TagSearchResult>,
+    user: &User,
+    configs: &VaultConfigCache,
+    default_roles: &[String],
+) -> Vec<crate::search::index::TagSearchResult> {
+    raw.into_iter()
+        .filter(|r| check_user_access(&r.path, user, configs, default_roles))
+        .collect()
+}
+
+fn filter_headings_by_access(
+    raw: Vec<crate::search::index::HeadingSearchResult>,
+    user: &User,
+    configs: &VaultConfigCache,
+    default_roles: &[String],
+) -> Vec<crate::search::index::HeadingSearchResult> {
+    raw.into_iter()
+        .filter(|r| check_user_access(&r.path, user, configs, default_roles))
+        .collect()
+}
+
+fn filter_and_map_content(
+    raw: Vec<crate::search::index::SearchResult>,
+    limit: usize,
+) -> Vec<SearchResultResponse> {
+    raw.into_iter()
+        .take(limit)
+        .map(|r| SearchResultResponse {
+            path: r.path,
+            title: r.title,
+            snippet: r.snippet,
+            score: r.score,
+            result_type: "content".to_string(),
+            anchor: None,
+            tag: None,
+            doc_count: None,
+            heading_level: None,
+        })
+        .collect()
+}
+
+fn filter_and_map_files(
+    raw: Vec<crate::search::index::SearchResult>,
+    limit: usize,
+) -> Vec<SearchResultResponse> {
+    raw.into_iter()
+        .take(limit)
+        .map(|r| SearchResultResponse {
+            path: r.path,
+            title: r.title,
+            snippet: String::new(),
+            score: r.score,
+            result_type: "file".to_string(),
+            anchor: None,
+            tag: None,
+            doc_count: None,
+            heading_level: None,
+        })
+        .collect()
+}
+
+fn aggregate_tags(
+    raw: Vec<crate::search::index::TagSearchResult>,
+    query: &str,
+    limit: usize,
+) -> Vec<SearchResultResponse> {
+    let mut tag_counts: HashMap<String, u32> = HashMap::new();
+
+    for result in &raw {
+        for tag in result.tags.split_whitespace() {
+            if query.is_empty() || tag.starts_with(&query.to_lowercase()) {
+                *tag_counts.entry(tag.to_string()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let mut tags: Vec<(String, u32)> = tag_counts.into_iter().collect();
+    tags.sort_by(|a, b| b.1.cmp(&a.1));
+
+    tags.into_iter()
+        .take(limit)
+        .map(|(tag, count)| SearchResultResponse {
+            path: String::new(),
+            title: tag.clone(),
+            snippet: String::new(),
+            score: count as f32,
+            result_type: "tag".to_string(),
+            anchor: None,
+            tag: Some(tag),
+            doc_count: Some(count),
+            heading_level: None,
+        })
+        .collect()
+}
+
+fn expand_headings(
+    raw: Vec<crate::search::index::HeadingSearchResult>,
+    query: &str,
+    limit: usize,
+) -> Vec<SearchResultResponse> {
+    let query_lower = query.to_lowercase();
+    let mut results = Vec::new();
+
+    for result in raw {
+        let headings: Vec<crate::docs::markdown::HeadingInfo> =
+            serde_json::from_str(&result.headings_data).unwrap_or_default();
+
+        for heading in headings {
+            if heading.text.to_lowercase().contains(&query_lower) {
+                results.push(SearchResultResponse {
+                    path: result.path.clone(),
+                    title: heading.text,
+                    snippet: result.title.clone(),
+                    score: result.score,
+                    result_type: "heading".to_string(),
+                    anchor: Some(heading.anchor),
+                    tag: None,
+                    doc_count: None,
+                    heading_level: Some(heading.level),
+                });
+            }
+        }
+    }
+
+    results.truncate(limit);
+    results
 }

--- a/src/backend/src/search/handlers.rs
+++ b/src/backend/src/search/handlers.rs
@@ -113,10 +113,9 @@ pub async fn search(
             SearchType::Tags => {
                 if let Some(ref exact_tag) = tag {
                     RawSearchData::Tags(index.search_by_tag(exact_tag, limit * 2))
-                } else if q.is_empty() {
-                    RawSearchData::Tags(index.all_tags())
                 } else {
-                    RawSearchData::Tags(index.search_tags(&q, limit * 2))
+                    // Always scan all docs - aggregate_tags does prefix filtering
+                    RawSearchData::Tags(index.all_tags())
                 }
             }
             SearchType::Headings => {
@@ -128,40 +127,28 @@ pub async fn search(
         }
     };
 
-    if auth_mode == AuthMode::None {
-        let results = tokio::task::spawn_blocking(move || match raw_data {
-            RawSearchData::Content(raw) => filter_and_map_content(raw, limit),
-            RawSearchData::Files(raw) => filter_and_map_files(raw, limit),
-            RawSearchData::Tags(raw) => aggregate_tags(raw, &q, limit),
-            RawSearchData::Headings(raw) => expand_headings(raw, &q, limit),
-        })
-        .await
-        .unwrap_or_default();
-        return Json(results).into_response();
-    }
-
-    let configs = {
+    let configs = if auth_mode != AuthMode::None {
         let guard = vault_configs.read().await;
-        guard.get(vault_name).cloned().unwrap_or_default()
+        Some(guard.get(vault_name).cloned().unwrap_or_default())
+    } else {
+        None
     };
 
+    macro_rules! apply_access {
+        ($raw:expr) => {
+            if let Some(ref configs) = configs {
+                filter_by_access($raw, |r| &r.path, &user, configs, &default_roles)
+            } else {
+                $raw
+            }
+        };
+    }
+
     let results = tokio::task::spawn_blocking(move || match raw_data {
-        RawSearchData::Content(raw) => {
-            let filtered = filter_by_access(raw, &user, &configs, &default_roles);
-            filter_and_map_content(filtered, limit)
-        }
-        RawSearchData::Files(raw) => {
-            let filtered = filter_by_access(raw, &user, &configs, &default_roles);
-            filter_and_map_files(filtered, limit)
-        }
-        RawSearchData::Tags(raw) => {
-            let filtered = filter_tags_by_access(raw, &user, &configs, &default_roles);
-            aggregate_tags(filtered, &q, limit)
-        }
-        RawSearchData::Headings(raw) => {
-            let filtered = filter_headings_by_access(raw, &user, &configs, &default_roles);
-            expand_headings(filtered, &q, limit)
-        }
+        RawSearchData::Content(raw) => filter_and_map_content(apply_access!(raw), limit),
+        RawSearchData::Files(raw) => filter_and_map_files(apply_access!(raw), limit),
+        RawSearchData::Tags(raw) => aggregate_tags(apply_access!(raw), &q, limit),
+        RawSearchData::Headings(raw) => expand_headings(apply_access!(raw), &q, limit),
     })
     .await
     .unwrap_or_default();
@@ -179,51 +166,32 @@ fn check_user_access(
     vault_config::check_access(&user.roles, &roles)
 }
 
-fn filter_by_access(
-    raw: Vec<crate::search::index::SearchResult>,
+fn filter_by_access<T>(
+    raw: Vec<T>,
+    get_path: impl Fn(&T) -> &str,
     user: &User,
     configs: &VaultConfigCache,
     default_roles: &[String],
-) -> Vec<crate::search::index::SearchResult> {
+) -> Vec<T> {
     raw.into_iter()
-        .filter(|r| check_user_access(&r.path, user, configs, default_roles))
+        .filter(|r| check_user_access(get_path(r), user, configs, default_roles))
         .collect()
 }
 
-fn filter_tags_by_access(
-    raw: Vec<crate::search::index::TagSearchResult>,
-    user: &User,
-    configs: &VaultConfigCache,
-    default_roles: &[String],
-) -> Vec<crate::search::index::TagSearchResult> {
-    raw.into_iter()
-        .filter(|r| check_user_access(&r.path, user, configs, default_roles))
-        .collect()
-}
-
-fn filter_headings_by_access(
-    raw: Vec<crate::search::index::HeadingSearchResult>,
-    user: &User,
-    configs: &VaultConfigCache,
-    default_roles: &[String],
-) -> Vec<crate::search::index::HeadingSearchResult> {
-    raw.into_iter()
-        .filter(|r| check_user_access(&r.path, user, configs, default_roles))
-        .collect()
-}
-
-fn filter_and_map_content(
+fn map_search_results(
     raw: Vec<crate::search::index::SearchResult>,
     limit: usize,
+    result_type: &str,
+    include_snippet: bool,
 ) -> Vec<SearchResultResponse> {
     raw.into_iter()
         .take(limit)
         .map(|r| SearchResultResponse {
+            snippet: if include_snippet { r.snippet } else { String::new() },
             path: r.path,
             title: r.title,
-            snippet: r.snippet,
             score: r.score,
-            result_type: "content".to_string(),
+            result_type: result_type.to_string(),
             anchor: None,
             tag: None,
             doc_count: None,
@@ -232,24 +200,12 @@ fn filter_and_map_content(
         .collect()
 }
 
-fn filter_and_map_files(
-    raw: Vec<crate::search::index::SearchResult>,
-    limit: usize,
-) -> Vec<SearchResultResponse> {
-    raw.into_iter()
-        .take(limit)
-        .map(|r| SearchResultResponse {
-            path: r.path,
-            title: r.title,
-            snippet: String::new(),
-            score: r.score,
-            result_type: "file".to_string(),
-            anchor: None,
-            tag: None,
-            doc_count: None,
-            heading_level: None,
-        })
-        .collect()
+fn filter_and_map_content(raw: Vec<crate::search::index::SearchResult>, limit: usize) -> Vec<SearchResultResponse> {
+    map_search_results(raw, limit, "content", true)
+}
+
+fn filter_and_map_files(raw: Vec<crate::search::index::SearchResult>, limit: usize) -> Vec<SearchResultResponse> {
+    map_search_results(raw, limit, "file", false)
 }
 
 fn aggregate_tags(
@@ -258,10 +214,11 @@ fn aggregate_tags(
     limit: usize,
 ) -> Vec<SearchResultResponse> {
     let mut tag_counts: HashMap<String, u32> = HashMap::new();
+    let query_lower = query.to_lowercase();
 
     for result in &raw {
         for tag in result.tags.split_whitespace() {
-            if query.is_empty() || tag.starts_with(&query.to_lowercase()) {
+            if query_lower.is_empty() || tag.contains(&query_lower) {
                 *tag_counts.entry(tag.to_string()).or_insert(0) += 1;
             }
         }

--- a/src/backend/src/search/index.rs
+++ b/src/backend/src/search/index.rs
@@ -16,6 +16,7 @@ pub struct SearchIndex {
     tags_field: Field,
     headings_text_field: Field,
     headings_data_field: Field,
+    all_tag_results: Vec<TagSearchResult>,
 }
 
 pub struct SearchResult {
@@ -32,29 +33,27 @@ pub struct HeadingSearchResult {
     pub score: f32,
 }
 
+#[derive(Clone)]
 pub struct TagSearchResult {
     pub path: String,
     pub tags: String,
-    pub score: f32,
 }
 
 impl SearchIndex {
     pub fn build(vault_root: &Path) -> anyhow::Result<Self> {
         let mut schema_builder = Schema::builder();
 
-        let ngram_options = TextOptions::default()
-            .set_indexing_options(
-                TextFieldIndexing::default()
-                    .set_tokenizer("ngram")
-                    .set_index_option(IndexRecordOption::WithFreqsAndPositions),
-            )
-            .set_stored();
+        let ngram_indexing = TextFieldIndexing::default()
+            .set_tokenizer("ngram")
+            .set_index_option(IndexRecordOption::WithFreqsAndPositions);
 
-        let path_field = schema_builder.add_text_field("path", ngram_options);
+        let path_field = schema_builder.add_text_field("path",
+            TextOptions::default().set_indexing_options(ngram_indexing.clone()).set_stored());
         let title_field = schema_builder.add_text_field("title", TEXT | STORED);
         let body_field = schema_builder.add_text_field("body", TEXT | STORED);
         let tags_field = schema_builder.add_text_field("tags", TEXT | STORED);
-        let headings_text_field = schema_builder.add_text_field("headings_text", TEXT);
+        let headings_text_field = schema_builder.add_text_field("headings_text",
+            TextOptions::default().set_indexing_options(ngram_indexing).set_stored());
         let headings_data_field = schema_builder.add_text_field("headings_data", STORED);
 
         let schema = schema_builder.build();
@@ -102,6 +101,23 @@ impl SearchIndex {
             .reload_policy(ReloadPolicy::Manual)
             .try_into()?;
 
+        let all_tag_results = {
+            let searcher = reader.searcher();
+            let total = searcher.num_docs() as usize;
+            let top_docs = searcher.search(&tantivy::query::AllQuery, &TopDocs::with_limit(total)).unwrap_or_default();
+            let mut results = Vec::new();
+            for (_score, doc_address) in top_docs {
+                if let Ok(retrieved) = searcher.doc::<TantivyDocument>(doc_address) {
+                    let tags = doc_field_text(&retrieved, tags_field);
+                    if !tags.is_empty() {
+                        let path = doc_field_text(&retrieved, path_field);
+                        results.push(TagSearchResult { path, tags });
+                    }
+                }
+            }
+            results
+        };
+
         Ok(Self {
             index,
             reader,
@@ -111,6 +127,7 @@ impl SearchIndex {
             tags_field,
             headings_text_field,
             headings_data_field,
+            all_tag_results,
         })
     }
 
@@ -122,7 +139,8 @@ impl SearchIndex {
         );
         query_parser.set_field_boost(self.title_field, 2.0);
 
-        let query = match query_parser.parse_query(query_str) {
+        let prefix_query = make_prefix_query(query_str);
+        let query = match query_parser.parse_query(&prefix_query) {
             Ok(q) => q,
             Err(_) => return Vec::new(),
         };
@@ -198,36 +216,6 @@ impl SearchIndex {
         results
     }
 
-    pub fn search_tags(&self, query_str: &str, limit: usize) -> Vec<TagSearchResult> {
-        let searcher = self.reader.searcher();
-        let query_parser = QueryParser::for_index(&self.index, vec![self.tags_field]);
-
-        let query = match query_parser.parse_query(query_str) {
-            Ok(q) => q,
-            Err(_) => return Vec::new(),
-        };
-
-        let top_docs = match searcher.search(&query, &TopDocs::with_limit(limit)) {
-            Ok(docs) => docs,
-            Err(_) => return Vec::new(),
-        };
-
-        let mut results = Vec::new();
-        for (score, doc_address) in top_docs {
-            let retrieved: TantivyDocument = match searcher.doc(doc_address) {
-                Ok(d) => d,
-                Err(_) => continue,
-            };
-
-            let path = doc_field_text(&retrieved, self.path_field);
-            let tags = doc_field_text(&retrieved, self.tags_field);
-
-            results.push(TagSearchResult { path, tags, score });
-        }
-
-        results
-    }
-
     pub fn search_headings(&self, query_str: &str, limit: usize) -> Vec<HeadingSearchResult> {
         let searcher = self.reader.searcher();
         let query_parser = QueryParser::for_index(&self.index, vec![self.headings_text_field]);
@@ -277,7 +265,7 @@ impl SearchIndex {
         };
 
         let mut results = Vec::new();
-        for (score, doc_address) in top_docs {
+        for (_score, doc_address) in top_docs {
             let retrieved: TantivyDocument = match searcher.doc(doc_address) {
                 Ok(d) => d,
                 Err(_) => continue,
@@ -286,43 +274,35 @@ impl SearchIndex {
             let path = doc_field_text(&retrieved, self.path_field);
             let tags = doc_field_text(&retrieved, self.tags_field);
 
-            results.push(TagSearchResult { path, tags, score });
+            results.push(TagSearchResult { path, tags });
         }
 
         results
     }
 
     pub fn all_tags(&self) -> Vec<TagSearchResult> {
-        use tantivy::query::AllQuery;
-
-        let searcher = self.reader.searcher();
-        let limit = searcher.num_docs() as usize;
-        if limit == 0 {
-            return Vec::new();
-        }
-
-        let top_docs = match searcher.search(&AllQuery, &TopDocs::with_limit(limit)) {
-            Ok(docs) => docs,
-            Err(_) => return Vec::new(),
-        };
-
-        let mut results = Vec::new();
-        for (score, doc_address) in top_docs {
-            let retrieved: TantivyDocument = match searcher.doc(doc_address) {
-                Ok(d) => d,
-                Err(_) => continue,
-            };
-
-            let path = doc_field_text(&retrieved, self.path_field);
-            let tags = doc_field_text(&retrieved, self.tags_field);
-
-            if !tags.is_empty() {
-                results.push(TagSearchResult { path, tags, score });
-            }
-        }
-
-        results
+        self.all_tag_results.clone()
     }
+}
+
+const TANTIVY_SPECIAL_CHARS: &[char] = &['\\', '"', '(', ')', '[', ']', '{', '}', '^', '~', ':', '+', '-'];
+
+fn make_prefix_query(query_str: &str) -> String {
+    query_str
+        .split_whitespace()
+        .map(|term| {
+            let mut escaped = String::with_capacity(term.len() * 2);
+            for ch in term.chars() {
+                if TANTIVY_SPECIAL_CHARS.contains(&ch) {
+                    escaped.push('\\');
+                }
+                escaped.push(ch);
+            }
+            escaped.push('*');
+            escaped
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn doc_field_text(doc: &TantivyDocument, field: Field) -> String {

--- a/src/backend/src/search/index.rs
+++ b/src/backend/src/search/index.rs
@@ -4,6 +4,7 @@ use tantivy::collector::TopDocs;
 use tantivy::query::QueryParser;
 use tantivy::schema::*;
 use tantivy::snippet::SnippetGenerator;
+use tantivy::tokenizer::NgramTokenizer;
 use tantivy::{doc, Index, IndexReader, ReloadPolicy, TantivyDocument};
 
 pub struct SearchIndex {
@@ -12,6 +13,9 @@ pub struct SearchIndex {
     path_field: Field,
     title_field: Field,
     body_field: Field,
+    tags_field: Field,
+    headings_text_field: Field,
+    headings_data_field: Field,
 }
 
 pub struct SearchResult {
@@ -21,16 +25,44 @@ pub struct SearchResult {
     pub score: f32,
 }
 
+pub struct HeadingSearchResult {
+    pub path: String,
+    pub title: String,
+    pub headings_data: String,
+    pub score: f32,
+}
+
+pub struct TagSearchResult {
+    pub path: String,
+    pub tags: String,
+    pub score: f32,
+}
+
 impl SearchIndex {
     pub fn build(vault_root: &Path) -> anyhow::Result<Self> {
         let mut schema_builder = Schema::builder();
 
-        let path_field = schema_builder.add_text_field("path", STRING | STORED);
+        let ngram_options = TextOptions::default()
+            .set_indexing_options(
+                TextFieldIndexing::default()
+                    .set_tokenizer("ngram")
+                    .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+            )
+            .set_stored();
+
+        let path_field = schema_builder.add_text_field("path", ngram_options);
         let title_field = schema_builder.add_text_field("title", TEXT | STORED);
         let body_field = schema_builder.add_text_field("body", TEXT | STORED);
+        let tags_field = schema_builder.add_text_field("tags", TEXT | STORED);
+        let headings_text_field = schema_builder.add_text_field("headings_text", TEXT);
+        let headings_data_field = schema_builder.add_text_field("headings_data", STORED);
 
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
+
+        index
+            .tokenizers()
+            .register("ngram", NgramTokenizer::new(2, 20, false)?);
 
         let mut writer = index.writer(50_000_000)?;
 
@@ -38,10 +70,28 @@ impl SearchIndex {
             let content = std::fs::read_to_string(full_path).unwrap_or_default();
             let (title, body) = extract_title_and_body(&content);
 
+            let tags_list = crate::docs::markdown::extract_tags(&content);
+            let tags_text = tags_list
+                .iter()
+                .map(|t| t.to_lowercase())
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            let headings = crate::docs::markdown::extract_headings(&content);
+            let headings_text = headings
+                .iter()
+                .map(|h| h.text.clone())
+                .collect::<Vec<_>>()
+                .join("\n");
+            let headings_json = serde_json::to_string(&headings).unwrap_or_default();
+
             let _ = writer.add_document(doc!(
                 path_field => rel_path.to_string(),
                 title_field => title,
                 body_field => body,
+                tags_field => tags_text,
+                headings_text_field => headings_text,
+                headings_data_field => headings_json,
             ));
         });
 
@@ -58,6 +108,9 @@ impl SearchIndex {
             path_field,
             title_field,
             body_field,
+            tags_field,
+            headings_text_field,
+            headings_data_field,
         })
     }
 
@@ -105,6 +158,167 @@ impl SearchIndex {
                 snippet,
                 score,
             });
+        }
+
+        results
+    }
+
+    pub fn search_files(&self, query_str: &str, limit: usize) -> Vec<SearchResult> {
+        let searcher = self.reader.searcher();
+        let query_parser = QueryParser::for_index(&self.index, vec![self.path_field]);
+
+        let query = match query_parser.parse_query(query_str) {
+            Ok(q) => q,
+            Err(_) => return Vec::new(),
+        };
+
+        let top_docs = match searcher.search(&query, &TopDocs::with_limit(limit)) {
+            Ok(docs) => docs,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut results = Vec::new();
+        for (score, doc_address) in top_docs {
+            let retrieved: TantivyDocument = match searcher.doc(doc_address) {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+
+            let path = doc_field_text(&retrieved, self.path_field);
+            let title = doc_field_text(&retrieved, self.title_field);
+
+            results.push(SearchResult {
+                path,
+                title,
+                snippet: String::new(),
+                score,
+            });
+        }
+
+        results
+    }
+
+    pub fn search_tags(&self, query_str: &str, limit: usize) -> Vec<TagSearchResult> {
+        let searcher = self.reader.searcher();
+        let query_parser = QueryParser::for_index(&self.index, vec![self.tags_field]);
+
+        let query = match query_parser.parse_query(query_str) {
+            Ok(q) => q,
+            Err(_) => return Vec::new(),
+        };
+
+        let top_docs = match searcher.search(&query, &TopDocs::with_limit(limit)) {
+            Ok(docs) => docs,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut results = Vec::new();
+        for (score, doc_address) in top_docs {
+            let retrieved: TantivyDocument = match searcher.doc(doc_address) {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+
+            let path = doc_field_text(&retrieved, self.path_field);
+            let tags = doc_field_text(&retrieved, self.tags_field);
+
+            results.push(TagSearchResult { path, tags, score });
+        }
+
+        results
+    }
+
+    pub fn search_headings(&self, query_str: &str, limit: usize) -> Vec<HeadingSearchResult> {
+        let searcher = self.reader.searcher();
+        let query_parser = QueryParser::for_index(&self.index, vec![self.headings_text_field]);
+
+        let query = match query_parser.parse_query(query_str) {
+            Ok(q) => q,
+            Err(_) => return Vec::new(),
+        };
+
+        let top_docs = match searcher.search(&query, &TopDocs::with_limit(limit)) {
+            Ok(docs) => docs,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut results = Vec::new();
+        for (score, doc_address) in top_docs {
+            let retrieved: TantivyDocument = match searcher.doc(doc_address) {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+
+            let path = doc_field_text(&retrieved, self.path_field);
+            let title = doc_field_text(&retrieved, self.title_field);
+            let headings_data = doc_field_text(&retrieved, self.headings_data_field);
+
+            results.push(HeadingSearchResult {
+                path,
+                title,
+                headings_data,
+                score,
+            });
+        }
+
+        results
+    }
+
+    pub fn search_by_tag(&self, tag: &str, limit: usize) -> Vec<TagSearchResult> {
+        use tantivy::query::TermQuery;
+
+        let searcher = self.reader.searcher();
+        let term = tantivy::Term::from_field_text(self.tags_field, tag);
+        let query = TermQuery::new(term, IndexRecordOption::Basic);
+
+        let top_docs = match searcher.search(&query, &TopDocs::with_limit(limit)) {
+            Ok(docs) => docs,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut results = Vec::new();
+        for (score, doc_address) in top_docs {
+            let retrieved: TantivyDocument = match searcher.doc(doc_address) {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+
+            let path = doc_field_text(&retrieved, self.path_field);
+            let tags = doc_field_text(&retrieved, self.tags_field);
+
+            results.push(TagSearchResult { path, tags, score });
+        }
+
+        results
+    }
+
+    pub fn all_tags(&self) -> Vec<TagSearchResult> {
+        use tantivy::query::AllQuery;
+
+        let searcher = self.reader.searcher();
+        let limit = searcher.num_docs() as usize;
+        if limit == 0 {
+            return Vec::new();
+        }
+
+        let top_docs = match searcher.search(&AllQuery, &TopDocs::with_limit(limit)) {
+            Ok(docs) => docs,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut results = Vec::new();
+        for (score, doc_address) in top_docs {
+            let retrieved: TantivyDocument = match searcher.doc(doc_address) {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+
+            let path = doc_field_text(&retrieved, self.path_field);
+            let tags = doc_field_text(&retrieved, self.tags_field);
+
+            if !tags.is_empty() {
+                results.push(TagSearchResult { path, tags, score });
+            }
         }
 
         results

--- a/src/frontend/src/app.css
+++ b/src/frontend/src/app.css
@@ -128,6 +128,15 @@
 	}
 }
 
+.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
+	scroll-margin-top: 4rem;
+}
+
+/* Search result highlight */
+[data-slot="command-item"] mark {
+	border-radius: 0.125rem;
+}
+
 .prose pre {
 	background-color: var(--muted) !important;
 	border: 1px solid var(--border);

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { User, FileNode, DocResponse, GraphData, SearchResult, VaultInfo } from './types';
+import type { User, FileNode, DocResponse, GraphData, SearchResult, VaultInfo, SearchType } from './types';
 
 type Fetch = typeof fetch;
 
@@ -38,10 +38,21 @@ export async function getGraph(f: Fetch, vault: string): Promise<GraphData> {
 	return res.json();
 }
 
-export async function searchDocs(f: Fetch, query: string, vault: string, limit = 10): Promise<SearchResult[]> {
-	const res = await f(
-		`/api/search?q=${encodeURIComponent(query)}&vault=${encodeURIComponent(vault)}&limit=${limit}`
-	);
+export async function searchDocs(
+	f: Fetch,
+	query: string,
+	vault: string,
+	searchType: SearchType = 'content',
+	limit = 20,
+	tag?: string
+): Promise<SearchResult[]> {
+	const params = new URLSearchParams();
+	if (query) params.set('q', query);
+	params.set('vault', vault);
+	params.set('limit', String(limit));
+	params.set('type', searchType);
+	if (tag) params.set('tag', tag);
+	const res = await f(`/api/search?${params.toString()}`);
 	if (!res.ok) return [];
 	return res.json();
 }

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -36,11 +36,18 @@ export interface GraphData {
 	edges: GraphEdge[];
 }
 
+export type SearchType = 'content' | 'files' | 'tags' | 'headings';
+
 export interface SearchResult {
 	path: string;
 	title: string;
 	snippet: string;
 	score: number;
+	result_type: string;
+	anchor?: string;
+	tag?: string;
+	doc_count?: number;
+	heading_level?: number;
 }
 
 export interface VaultInfo {

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -21,6 +21,13 @@
 	);
 	let selectedTag = $state<string | null>(null);
 
+	const searchLabels: Record<SearchType, { placeholder: string; empty: string; heading: string }> = {
+		content: { placeholder: 'Search content...', empty: 'No documents found.', heading: 'Results' },
+		files: { placeholder: 'Search files...', empty: 'No files found.', heading: 'Files' },
+		tags: { placeholder: 'Search tags...', empty: 'No tags found.', heading: 'Tags' },
+		headings: { placeholder: 'Search headings...', empty: 'No headings found.', heading: 'Headings' },
+	};
+
 	let vault = $derived((() => {
 		const match = page.url.pathname.match(/^\/(docs|graph)\/([^/]+)/);
 		return match ? match[2] : null;
@@ -79,10 +86,21 @@
 		}
 	}
 
+	function escapeHtml(s: string): string {
+		return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+	}
+
 	function sanitizeSnippet(html: string): string {
-		let safe = html.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-		safe = safe.replace(/&lt;b&gt;/g, '<b>').replace(/&lt;\/b&gt;/g, '</b>');
+		let safe = escapeHtml(html);
+		safe = safe.replace(/&lt;b&gt;/g, '<mark>').replace(/&lt;\/b&gt;/g, '</mark>');
 		return safe;
+	}
+
+	function highlightMatch(text: string, q: string): string {
+		const escaped = escapeHtml(text);
+		if (!q) return escaped;
+		const re = new RegExp(`(${q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
+		return escaped.replace(re, '<mark>$1</mark>');
 	}
 
 	function setSearchType(t: SearchType) {
@@ -187,6 +205,7 @@
 			{ type: 'headings', label: 'Headings', key: '4' }
 		] as tab}
 			<button
+				tabindex={-1}
 				class="rounded-md px-2.5 py-1 text-xs font-medium transition-colors {searchType === tab.type
 					? 'bg-accent text-accent-foreground'
 					: 'text-muted-foreground hover:text-foreground hover:bg-accent/50'}"
@@ -200,40 +219,23 @@
 	{#if selectedTag}
 		<div class="flex items-center gap-2 border-b px-3 py-2">
 			<span class="bg-primary/10 text-primary rounded px-2 py-0.5 text-xs font-medium">#{selectedTag}</span>
-			<button class="text-muted-foreground hover:text-foreground text-xs" onclick={clearTag}>clear</button>
+			<button tabindex={-1} class="text-muted-foreground hover:text-foreground text-xs" onclick={clearTag}>clear</button>
 		</div>
 	{/if}
-	<Command.Input
-		placeholder={searchType === 'content'
-			? 'Search content...'
-			: searchType === 'files'
-				? 'Search files...'
-				: searchType === 'tags'
-					? 'Search tags...'
-					: 'Search headings...'}
-		bind:value={query}
-	/>
+	<Command.Input placeholder={searchLabels[searchType].placeholder} bind:value={query} />
 	<Command.List>
 		{#if (query.trim().length > 0 || selectedTag) && results.length === 0}
-			<Command.Empty>
-				{searchType === 'content'
-					? 'No documents found.'
-					: searchType === 'files'
-						? 'No files found.'
-						: searchType === 'tags'
-							? 'No tags found.'
-							: 'No headings found.'}
-			</Command.Empty>
+			<Command.Empty>{searchLabels[searchType].empty}</Command.Empty>
 		{/if}
 		{#if results.length > 0}
-			<Command.Group heading={selectedTag ? `Documents with #${selectedTag}` : searchType === 'content' ? 'Results' : searchType === 'files' ? 'Files' : searchType === 'tags' ? 'Tags' : 'Headings'}>
+			<Command.Group heading={selectedTag ? `Documents with #${selectedTag}` : searchLabels[searchType].heading}>
 				{#each results as result (result.result_type === 'tag' ? result.tag : `${result.path}${result.anchor ?? ''}`)}
 					<Command.Item onSelect={() => selectResult(result)}>
 						{#if result.result_type === 'tag'}
 							<div class="flex w-full items-center justify-between">
 								<div class="flex items-center gap-2">
 									<Hash class="text-muted-foreground h-3.5 w-3.5" />
-									<span class="text-sm font-medium">{result.tag}</span>
+									<span class="text-sm font-medium">{@html highlightMatch(result.tag ?? '', query)}</span>
 								</div>
 								<span class="text-muted-foreground text-xs">{result.doc_count} docs</span>
 							</div>
@@ -241,7 +243,7 @@
 							<div class="flex items-center gap-2">
 								<span class="text-muted-foreground text-[10px] font-bold">H{result.heading_level}</span>
 								<div class="flex flex-col gap-0.5">
-									<span class="text-sm font-medium">{result.snippet}</span>
+									<span class="text-sm font-medium">{@html highlightMatch(result.title, query)}</span>
 									<span class="text-muted-foreground text-xs">{result.path}</span>
 								</div>
 							</div>
@@ -249,7 +251,7 @@
 							<div class="flex items-center gap-2">
 								<FileText class="text-muted-foreground h-3.5 w-3.5" />
 								<div class="flex flex-col gap-0.5">
-									<span class="text-sm font-medium">{result.path}</span>
+									<span class="text-sm font-medium">{@html highlightMatch(result.path, query)}</span>
 									{#if result.title}
 										<span class="text-muted-foreground text-xs">{result.title}</span>
 									{/if}
@@ -260,7 +262,7 @@
 								<span class="text-sm font-medium">{result.title || result.path}</span>
 								<span class="text-muted-foreground text-xs">{result.path}</span>
 								{#if result.snippet}
-									<span class="text-muted-foreground mt-0.5 text-xs [&_b]:font-medium">
+									<span class="text-muted-foreground mt-0.5 text-xs">
 										{@html sanitizeSnippet(result.snippet)}
 									</span>
 								{/if}

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -6,16 +6,20 @@
 	import { page } from '$app/state';
 	import { searchOpen, searchQuery, toggleSearch } from '$lib/search';
 	import { searchDocs } from '$lib/api';
-	import type { SearchResult } from '$lib/types';
+	import type { SearchResult, SearchType } from '$lib/types';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Command from '$lib/components/ui/command/index.js';
 	import ThemeToggle from '$lib/components/theme-toggle.svelte';
-	import { Network, Search, LogIn, LogOut, Library } from '@lucide/svelte';
+	import { Network, Search, LogIn, LogOut, Library, FileText, Hash } from '@lucide/svelte';
 
 	let { data, children }: { data: LayoutData; children: Snippet } = $props();
 
 	let query = $state('');
 	let results = $state<SearchResult[]>([]);
+	let searchType = $state<SearchType>(
+		(typeof localStorage !== 'undefined' && localStorage.getItem('vellum-search-type') as SearchType) || 'content'
+	);
+	let selectedTag = $state<string | null>(null);
 
 	let vault = $derived((() => {
 		const match = page.url.pathname.match(/^\/(docs|graph)\/([^/]+)/);
@@ -26,6 +30,7 @@
 		if (!$searchOpen) {
 			query = '';
 			results = [];
+			selectedTag = null;
 			searchQuery.set('');
 			return;
 		}
@@ -38,14 +43,24 @@
 
 	$effect(() => {
 		const q = query.trim();
-		if (!q) {
+		const currentType = searchType;
+		const currentTag = selectedTag;
+		const searchVault = vault ?? 'docs';
+
+		if (!q && !currentTag) {
 			results = [];
 			return;
 		}
-		const searchVault = vault ?? 'docs';
+
+		if (currentType === 'files' && q.length < 2) {
+			results = [];
+			return;
+		}
+
+		const debounceMs = currentType === 'content' ? 300 : 150;
 		const timer = setTimeout(async () => {
-			results = await searchDocs(fetch, q, searchVault);
-		}, 300);
+			results = await searchDocs(fetch, q, searchVault, currentType, 20, currentTag ?? undefined);
+		}, debounceMs);
 		return () => clearTimeout(timer);
 	});
 
@@ -53,6 +68,14 @@
 		if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
 			e.preventDefault();
 			toggleSearch();
+		}
+		if ($searchOpen && e.altKey) {
+			const modes: SearchType[] = ['content', 'files', 'tags', 'headings'];
+			const idx = parseInt(e.key) - 1;
+			if (idx >= 0 && idx < modes.length) {
+				e.preventDefault();
+				setSearchType(modes[idx]);
+			}
 		}
 	}
 
@@ -62,10 +85,36 @@
 		return safe;
 	}
 
+	function setSearchType(t: SearchType) {
+		searchType = t;
+		selectedTag = null;
+		query = '';
+		results = [];
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem('vellum-search-type', t);
+		}
+	}
+
+	function selectTag(tagName: string) {
+		selectedTag = tagName;
+		query = '';
+	}
+
+	function clearTag() {
+		selectedTag = null;
+		query = '';
+		results = [];
+	}
+
 	function selectResult(result: SearchResult) {
+		if (result.result_type === 'tag' && result.tag) {
+			selectTag(result.tag);
+			return;
+		}
 		searchOpen.set(false);
 		const targetVault = vault ?? 'docs';
-		goto(`/docs/${targetVault}/${result.path}`);
+		const anchor = result.anchor ? `#${result.anchor}` : '';
+		goto(`/docs/${targetVault}/${result.path}${anchor}`);
 	}
 </script>
 
@@ -130,24 +179,93 @@
 </div>
 
 <Command.Dialog bind:open={$searchOpen} title="Search documents" description="Search for documents in your vault" shouldFilter={false}>
-	<Command.Input placeholder="Search documents..." bind:value={query} />
+	<div class="flex gap-1 border-b px-3 py-2">
+		{#each [
+			{ type: 'content', label: 'Content', key: '1' },
+			{ type: 'files', label: 'Files', key: '2' },
+			{ type: 'tags', label: 'Tags', key: '3' },
+			{ type: 'headings', label: 'Headings', key: '4' }
+		] as tab}
+			<button
+				class="rounded-md px-2.5 py-1 text-xs font-medium transition-colors {searchType === tab.type
+					? 'bg-accent text-accent-foreground'
+					: 'text-muted-foreground hover:text-foreground hover:bg-accent/50'}"
+				onclick={() => setSearchType(tab.type as SearchType)}
+			>
+				{tab.label}
+				<kbd class="ml-1 text-[9px] opacity-50">Alt+{tab.key}</kbd>
+			</button>
+		{/each}
+	</div>
+	{#if selectedTag}
+		<div class="flex items-center gap-2 border-b px-3 py-2">
+			<span class="bg-primary/10 text-primary rounded px-2 py-0.5 text-xs font-medium">#{selectedTag}</span>
+			<button class="text-muted-foreground hover:text-foreground text-xs" onclick={clearTag}>clear</button>
+		</div>
+	{/if}
+	<Command.Input
+		placeholder={searchType === 'content'
+			? 'Search content...'
+			: searchType === 'files'
+				? 'Search files...'
+				: searchType === 'tags'
+					? 'Search tags...'
+					: 'Search headings...'}
+		bind:value={query}
+	/>
 	<Command.List>
-		{#if query.trim().length > 0 && results.length === 0}
-			<Command.Empty>No results found.</Command.Empty>
+		{#if (query.trim().length > 0 || selectedTag) && results.length === 0}
+			<Command.Empty>
+				{searchType === 'content'
+					? 'No documents found.'
+					: searchType === 'files'
+						? 'No files found.'
+						: searchType === 'tags'
+							? 'No tags found.'
+							: 'No headings found.'}
+			</Command.Empty>
 		{/if}
 		{#if results.length > 0}
-			<Command.Group heading="Results">
-				{#each results as result (result.path)}
+			<Command.Group heading={selectedTag ? `Documents with #${selectedTag}` : searchType === 'content' ? 'Results' : searchType === 'files' ? 'Files' : searchType === 'tags' ? 'Tags' : 'Headings'}>
+				{#each results as result (result.result_type === 'tag' ? result.tag : `${result.path}${result.anchor ?? ''}`)}
 					<Command.Item onSelect={() => selectResult(result)}>
-						<div class="flex flex-col gap-0.5">
-							<span class="text-sm font-medium">{result.title || result.path}</span>
-							<span class="text-muted-foreground text-xs">{result.path}</span>
-							{#if result.snippet}
-								<span class="text-muted-foreground mt-0.5 text-xs [&_mark]:bg-primary/20 [&_mark]:font-medium">
-									{@html sanitizeSnippet(result.snippet)}
-								</span>
-							{/if}
-						</div>
+						{#if result.result_type === 'tag'}
+							<div class="flex w-full items-center justify-between">
+								<div class="flex items-center gap-2">
+									<Hash class="text-muted-foreground h-3.5 w-3.5" />
+									<span class="text-sm font-medium">{result.tag}</span>
+								</div>
+								<span class="text-muted-foreground text-xs">{result.doc_count} docs</span>
+							</div>
+						{:else if result.result_type === 'heading'}
+							<div class="flex items-center gap-2">
+								<span class="text-muted-foreground text-[10px] font-bold">H{result.heading_level}</span>
+								<div class="flex flex-col gap-0.5">
+									<span class="text-sm font-medium">{result.snippet}</span>
+									<span class="text-muted-foreground text-xs">{result.path}</span>
+								</div>
+							</div>
+						{:else if result.result_type === 'file'}
+							<div class="flex items-center gap-2">
+								<FileText class="text-muted-foreground h-3.5 w-3.5" />
+								<div class="flex flex-col gap-0.5">
+									<span class="text-sm font-medium">{result.path}</span>
+									{#if result.title}
+										<span class="text-muted-foreground text-xs">{result.title}</span>
+									{/if}
+								</div>
+							</div>
+						{:else}
+							<div class="flex flex-col gap-0.5">
+								<span class="text-sm font-medium">{result.title || result.path}</span>
+								<span class="text-muted-foreground text-xs">{result.path}</span>
+								{#if result.snippet}
+									<span class="text-muted-foreground mt-0.5 text-xs [&_b]:font-medium">
+										{@html sanitizeSnippet(result.snippet)}
+									</span>
+								{/if}
+							</div>
+						{/if}
 					</Command.Item>
 				{/each}
 			</Command.Group>

--- a/vaults/dev/api-reference.md
+++ b/vaults/dev/api-reference.md
@@ -167,14 +167,20 @@ Nodes represent documents. Edges represent `[[wikilinks]]` from one document to 
 
 ### GET /api/search
 
-Full-text search across accessible documents.
+Full-text search across accessible documents with multiple search modes.
 
 **Query parameters:**
-- `q` (required) - search query string
+- `q` (optional) - search query string (required for `content`, `files`, `headings` modes; optional for `tags`)
+- `type` (optional) - search mode, defaults to `content`
+  - `content` - full-text search across titles and bodies
+  - `files` - fuzzy search by file name/path (requires min 2 characters in `q`)
+  - `tags` - browse all tags with document counts
+  - `headings` - search headings across documents
+- `tag` (optional) - exact tag name to filter results (used with `files` or `content` types for tag drill-down)
 - `limit` (optional) - max results, default `20`
 - `vault` (optional) - vault name
 
-**Response (200):**
+**Response (200) - Content/Files/Headings:**
 
 ```json
 [
@@ -187,10 +193,20 @@ Full-text search across accessible documents.
 ]
 ```
 
-**Errors:**
-- `400` - missing `q` parameter
+**Response (200) - Tags:**
 
-Results are filtered by user roles. Snippets contain highlighted matching terms.
+```json
+[
+  { "tag": "tutorial", "count": 12 },
+  { "tag": "api", "count": 8 },
+  { "tag": "setup", "count": 5 }
+]
+```
+
+**Errors:**
+- `400` - missing required `q` parameter for this mode
+
+Results are filtered by user roles. Snippets (in non-tag modes) contain highlighted matching terms.
 
 ---
 

--- a/vaults/docs/changelog.md
+++ b/vaults/docs/changelog.md
@@ -12,6 +12,10 @@ All notable changes to Vellum are documented here. This project follows [Semanti
 ### Added
 - Multi-vault support - configure multiple independent document repositories
 - Full-text search powered by Tantivy with `Cmd+K` command palette
+  - Four search modes: Content, Files, Tags, Headings
+  - Alt+1-4 shortcuts to switch modes
+  - Last used mode persisted in browser
+  - Tag drill-down: click tag to see related documents
 - Graph view showing `[[wikilink]]` relationships between documents
 - Role-based access control via `.vault.toml` per directory
 - OIDC authentication with Keycloak (Authorization Code Flow)

--- a/vaults/docs/features.md
+++ b/vaults/docs/features.md
@@ -63,6 +63,17 @@ Search across all accessible documents instantly:
 - Command palette UI (`Cmd+K` / `Ctrl+K`)
 - Debounced input with highlighted snippets
 
+### Search modes
+
+The command palette provides four specialized search modes (tab bar or `Alt+1-4`):
+
+- **Content** - full-text search across document titles and bodies
+- **Files** - fuzzy search by file name and path (minimum 2 characters)
+- **Tags** - browse all tags with document counts, click to drill down
+- **Headings** - search headings across all documents, jump to section with anchor
+
+Last used mode is remembered in your browser. Each mode has optimized debounce timing for responsiveness.
+
 ## Markdown rendering
 
 Vellum supports rich Markdown with extensions:


### PR DESCRIPTION
## Summary

Closes #2

- Extend Cmd+K command palette from single full-text search to four modes: **Content**, **Files**, **Tags**, **Headings**
- Tab bar with Alt+1-4 keyboard shortcuts, mode persisted in localStorage
- Tantivy index extended with ngram path field, tags, and headings fields
- Contains/substring matching for Files and Headings (ngram tokenizer), prefix matching for Content
- Tag drill-down: click tag to see matching documents
- Heading navigation with anchor links and scroll-margin-top offset
- Match highlighting with `<mark>` across all search modes
- Access control applied consistently across all search types
- Pre-computed tag results at index build time for fast tag browsing

## Test plan

- [ ] Cmd+K opens with 4 tabs (Content, Files, Tags, Headings)
- [ ] Content search works with prefix matching ("instal" finds "installation")
- [ ] Files search finds by path substring ("api" finds "dev/api-reference.md")
- [ ] Tags search shows tags with doc counts, click drills into documents
- [ ] Headings search finds by substring ("ext" finds "text"), click navigates to section
- [ ] Alt+1-4 switches modes, input stays focused
- [ ] Matched text highlighted with yellow background
- [ ] Heading anchors visible (not hidden under sticky nav)
- [ ] Access control: restricted docs/tags/headings not visible to unauthorized users